### PR TITLE
close #35

### DIFF
--- a/app/assets/stylesheets/knowledge.scss
+++ b/app/assets/stylesheets/knowledge.scss
@@ -4,6 +4,9 @@
     margin: 20px 10px;
   }
   .knowledge-title {
+    font-size: 2rem;
+    font-weight: 600;
+    line-height: 1.125;
     text-decoration: underline 4px;
     text-decoration-skip-ink: none;
   }
@@ -35,15 +38,23 @@
   .table th,td{
     vertical-align: inherit;
   }
-  .item-header {
-    display: flex;
+
+  .knowledge-header {
+    margin-bottom: 10px;
     align-items: center;
-    column-gap: 10px;
-    margin: 10px;
     img {
       border: solid $red 4px;
       border-radius: 50%;
       object-fit: contain;
+    }
+    @include mobile {
+      .media-content {
+        overflow-y: hidden;
+      }
+      img {
+        height: 74px;
+        width: 74px;
+      }
     }
   }
 }

--- a/app/views/lines/show.html.erb
+++ b/app/views/lines/show.html.erb
@@ -7,15 +7,17 @@
         <li><%= link_to @line.item.name, item_path(@line.item.name) %></li>
       </ul>
     </nav>
-    <div class='item-header is-vcentered'>
-      <% if @line.image %>
-        <figure>
+    <div class='knowledge-header media'>
+      <figure class='media-left'>
+        <% if @line.image %>
           <%= image_tag @line.image.variant(resize_to_limit: [200, 200]), class: 'image is-96x96' %>
-        </figure>
-      <% end %>
-      <h2 class='title knowledge-title'>
-        <%= @line.name %>
-      </h2>
+        <% end %>
+      </figure>
+      <div class='media-content'>
+        <h2 class='knowledge-title'>
+          <%= @line.name %>
+        </h2>
+      </div>
     </div>
     <%= render 'knowledges/card_list', objects: @line.knowledges %>
     <%= link_to 'トップページに戻る', root_path %>


### PR DESCRIPTION
# issue
- #35 

# 概要
bulmaのmediaクラスを使うことでレスポンシブ対応。画像が潰れなくなった

# 変更前
<img width="404" alt="image" src="https://github.com/atsushimemet/vook_web_v3/assets/69446373/073a369f-b1e7-4f5a-b720-b0276665ac4e">

# 変更後
<img width="416" alt="image" src="https://github.com/atsushimemet/vook_web_v3/assets/69446373/3c3818fb-67ef-48f3-97c5-d71c523ef39f">
