### PR TITLE
close #41

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,6 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'bullet'
   gem 'debug', platforms: %i[mri mingw x64_mingw]
-  gem 'dotenv-rails'
   gem 'factory_bot_rails'
   gem 'rspec-rails'
 end
@@ -85,6 +84,7 @@ group :test do
   gem 'webdrivers'
 end
 
+gem 'dotenv-rails'
 gem 'meta-tags'
 gem 'omniauth'
 gem 'omniauth-google-oauth2'


### PR DESCRIPTION
# issue
- #41  

# 修正内容
dotenv-railsを本番環境でも使用できるように設定
これでGoogle認証が可能になる