### PR TITLE
close #43

### DIFF
--- a/app/assets/stylesheets/magazine.scss
+++ b/app/assets/stylesheets/magazine.scss
@@ -23,6 +23,11 @@
   .card-image img {
     object-fit: contain;
   }
+  .read-more-button {
+    i {
+      margin-left: 6px;
+    }
+  }
 }
 
 .form-section {

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -62,8 +62,10 @@
   <%= render partial: 'shared/hero_banner', locals: { number: 1, title: 'Vook Magazine' } %>
   <div class="magazine-section container">
     <%= render 'magazines/card_list', magazines: @magazines %>
-    <div class='has-text-right'>
-      <%= link_to 'Magazineをもっと読む', magazines_path %>
+    <div class='read-more-button has-text-centered'>
+      <%= link_to magazines_path, class: 'button is-light is-large' do %>
+        Read more Magazines<i class="fa-solid fa-circle-right"></i>
+      <% end %>
     </div>
   </div>
 </section>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -61,29 +61,7 @@
 <section>
   <%= render partial: 'shared/hero_banner', locals: { number: 1, title: 'Vook Magazine' } %>
   <div class="magazine-section container">
-    <div class="columns is-mobile is-multiline">
-      <% @magazines.each do |magazine| %>
-        <div class='column is-one-quarter-tablet is-half-mobile'>
-          <div class='card'>
-            <%= link_to magazine do %>
-              <span class="magazine-date">
-                <%= l magazine.publish_at, format: :date %>
-              </span>
-              <div class='card-image'>
-                <figure class="image is-4by3">
-                  <%= image_tag magazine.thumbnail.variant(resize_to_limit: [400, 400]) %>
-                </figure>
-              </div>
-              <div class='card-content'>
-                <h3 class="card-header-title">
-                  <%= magazine.title %>
-                </h3>
-              </div>
-            <% end %>
-          </div>
-        </div>
-      <% end %>
-    </div>
+    <%= render 'magazines/card_list', magazines: @magazines %>
     <div class='has-text-right'>
       <%= link_to 'Magazineをもっと読む', magazines_path %>
     </div>

--- a/app/views/magazines/_card_list.html.erb
+++ b/app/views/magazines/_card_list.html.erb
@@ -8,7 +8,9 @@
           </span>
           <div class='card-image'>
             <figure class="image is-4by3">
-              <%= image_tag magazine.thumbnail.variant(resize_to_limit: [400, 400]) %>
+              <% if magazine.thumbnail.attached? %>
+                <%= image_tag magazine.thumbnail.variant(resize_to_limit: [400, 400]) %>
+              <% end %>
             </figure>
           </div>
           <div class='card-content'>

--- a/spec/factories/magazines.rb
+++ b/spec/factories/magazines.rb
@@ -40,4 +40,17 @@ FactoryBot.define do
       )
     end
   end
+
+  factory :no_thumbnail_magazine, class: 'Magazine' do
+    title { 'サムネイル画像がない記事' }
+    publish_at { Date.current }
+    after(:create) do |magazine|
+      ActionText::RichText.create!(
+        record_type: 'Magazine',
+        record_id: magazine.id,
+        name: 'body',
+        body: 'この記事にはサムネイルがありません'
+      )
+    end
+  end
 end

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+# RSpec.describe '/', type: :system do
+#   let(:user) { create(:admin) }
+#   let!(:no_thumbnail_magazine) { create(:no_thumbnail_magazine, user_id: user.id) }
+
+#   it 'サムネイル画像のない記事があってもトップページが表示されること' do
+#     visit root_path
+#     expect(page).to have_content 'サムネイル画像がない記事'
+#   end
+# end


### PR DESCRIPTION
# issue
- #43 

# 概要
- サムネイルを付与しない記事を作成してもエラーにならないよう修正
- ボタンにデザインも当てた

<img width="1033" alt="image" src="https://github.com/atsushimemet/vook_web_v3/assets/69446373/2cfbde00-036d-4387-898c-c1bfa72ced45">

# 備考
マージ後本番環境にも反映予定