### PR TITLE
close #50

### DIFF
--- a/app/views/knowledges/_card_list.html.erb
+++ b/app/views/knowledges/_card_list.html.erb
@@ -10,7 +10,9 @@
             <div class='card-image'>
               <% if object.image %>
                 <figure class='image is-4by3'>
-                  <%= image_tag object.image.variant(resize_to_limit: [400, 400]) %>
+                  <% if object.image.attached? %>
+                    <%= image_tag object.image.variant(resize_to_limit: [400, 400]) %>
+                  <% end %>
                 </figure>
               <% end %>
             </div>

--- a/spec/system/knowledges_spec.rb
+++ b/spec/system/knowledges_spec.rb
@@ -58,6 +58,19 @@
 #       expect(page).to have_content '紙パッチ'
 #     end
 
+#     it 'イメージ画像のない知識詳細ページへ遷移できること' do
+#       create(:no_image_knowledge, user_id: user.id, brand_id: brand.id, item_id: item.id, line_id: line.id)
+
+#       visit root_path
+#       find('a', text: 'ITEM').click
+#       click_on 'Denim'
+#       expect(page).to have_content 'Denim'
+#       click_on '501XX'
+#       expect(page).to have_content '501XX'
+#       click_on 'イメージ画像がない知識'
+#       expect(page).to have_content 'この知識にはイメージがありません'
+#     end
+
 #     it '管理者以外は記事編集と記事削除ボタンが表示されないこと' do
 #       sign_in_as(non_admin, uid: '5678')
 #       visit knowledge_path(knowledge)


### PR DESCRIPTION
# issue
- #50 

# 概要
画像のない知識を表示できるよう修正

<img width="776" alt="image" src="https://github.com/atsushimemet/vook_web_v3/assets/69446373/86bbe82d-4c38-4009-ae3a-de1094439e0a">

<img width="523" alt="image" src="https://github.com/atsushimemet/vook_web_v3/assets/69446373/dcf0442e-c310-493a-9de1-12850850a1ad">
