### PR TITLE
close #51

### DIFF
--- a/app/assets/stylesheets/application.bulma.scss
+++ b/app/assets/stylesheets/application.bulma.scss
@@ -28,6 +28,9 @@ body {
   a:hover {
     text-decoration: underline;
   }
+  .card {
+    height: 100%;
+  }
 }
 main {
   flex: 1;


### PR DESCRIPTION
# issue
- #51 
# 概要
カードのheightを100%表示にさせ、

| 変更前 | 変更後 |
| ---- | ---- |
|<img width="968" alt="image" src="https://github.com/atsushimemet/vook_web_v3/assets/69446373/dcf68e73-2e64-4535-9ef1-e83f5a076c16">|<img width="970" alt="image" src="https://github.com/atsushimemet/vook_web_v3/assets/69446373/13dc232d-5278-43e4-ae3f-8013bae9d8e1">|