### PR TITLE
close #163

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,16 @@
     <%= stylesheet_link_tag 'https://fonts.googleapis.com/css2?family=Open+Sans&family=Noto+Sans+JP&display=swap' %>
     <%= javascript_include_tag 'application', "data-turbo-track": 'reload', defer: true %>
     <%= hotwire_livereload_tags if Rails.env.development? %>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEB5PLKSXC"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-GEB5PLKSXC');
+    </script>
   </head>
 
   <body>


### PR DESCRIPTION
# Issue
- close #163

# やったこと
- ウェブサイトのすべてのページのコード（<head> 要素の直後）にGoogleタグを貼り付け

# レビュー頂きたい観点
- application.html.erbにGoogleタグを埋め込めば、ウェブサイトのすべてのページのコードにGoogleタグを埋め込んだことになるか

# 参考
- 
<img width="1440" alt="スクリーンショット 2023-10-03 0 05 44" src="https://github.com/atsushimemet/vook_web_v3/assets/25111665/709ed369-1c56-4542-9f44-d25550516efc">

