### PR TITLE
close #308

### DIFF
--- a/app/controllers/brands_controller.rb
+++ b/app/controllers/brands_controller.rb
@@ -7,7 +7,11 @@ class BrandsController < ApplicationController
   end
 
   def show
-    @brand = Brand.includes(lines: { image_attachment: :blob }).find_by(name: params[:name])
+    @brand = Brand.find_by(name: params[:name])
+    @lines = @brand.lines.left_joins(:knowledges)
+                   .includes(image_attachment: :blob)
+                   .group('lines.id')
+                   .order('COUNT(knowledges.id) DESC')
   end
 
   def edit; end

--- a/app/controllers/brands_controller.rb
+++ b/app/controllers/brands_controller.rb
@@ -8,10 +8,7 @@ class BrandsController < ApplicationController
 
   def show
     @brand = Brand.find_by(name: params[:name])
-    @lines = @brand.lines.left_joins(:knowledges)
-                   .includes(image_attachment: :blob)
-                   .group('lines.id')
-                   .order('COUNT(knowledges.id) DESC')
+    @lines = @brand.lines.includes(image_attachment: :blob).knowledge_count_order
   end
 
   def edit; end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,8 +2,8 @@ class HomeController < ApplicationController
   def index
     @first_brands = Brand.with_attached_image.order(:display_order).limit(8)
     @more_brands = Brand.with_attached_image.order(:display_order).offset(8)
-    @first_items = Item.with_attached_image.order(:display_order).limit(8)
-    @more_items = Item.with_attached_image.order(:display_order).offset(8)
+    @first_items = Item.with_attached_image.knowledge_count_order.limit(8)
+    @more_items = Item.with_attached_image.knowledge_count_order.offset(8)
     @magazines = Magazine.published.with_attached_thumbnail.order(publish_at: :desc).limit(8)
     @pickup_knowledges = current_pickup_knowledge
     @instagram_feeds = instagram_feed_cache

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,8 +7,8 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.includes(lines: { image_attachment: :blob }).find_by(name: params[:name])
-    @lines = @item.lines.includes(:brand).order('brands.display_order')
+    @item = Item.find_by(name: params[:name])
+    @lines = @item.lines.includes(image_attachment: :blob).knowledge_count_order
   end
 
   def edit; end

--- a/app/javascript/price-histogram.js
+++ b/app/javascript/price-histogram.js
@@ -10,7 +10,7 @@ document.addEventListener('turbo:load', () => {
       const response = await fetch(`/api/products/${productId}`);
       const products = await response.json();
 
-      if (products.length === 0) {
+      if (products.length <= 1) {
         // データがない場合の処理
         priceHistogram.innerHTML = '';
         return;

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,6 +14,12 @@ class Item < ApplicationRecord
     name
   end
 
+  scope :knowledge_count_order, lambda {
+    left_joins(:knowledges)
+      .group('items.id')
+      .order('COUNT(knowledges.id) DESC')
+  }
+
   private
 
   def set_default_display_order

--- a/app/models/line.rb
+++ b/app/models/line.rb
@@ -9,4 +9,10 @@ class Line < ApplicationRecord
   def to_param
     name
   end
+
+  scope :knowledge_count_order, lambda {
+    left_joins(:knowledges)
+      .group('lines.id')
+      .order('COUNT(knowledges.id) DESC')
+  }
 end

--- a/app/views/brands/show.html.erb
+++ b/app/views/brands/show.html.erb
@@ -17,7 +17,7 @@
         <%= @brand.description %>
       </div>
     <% end %>
-    <%= render 'knowledges/card_list', objects: @brand.lines %>
+    <%= render 'knowledges/card_list', objects: @lines %>
     <%= link_to 'トップページに戻る', root_path %>
   </div>
 </section>


### PR DESCRIPTION
# issue
- #308 
# やったこと
- ブランドページのラインを知識数順に並び替え
- アイテムページのラインを知識数順に並び替え
- トップページのアイテムを知識数順に並び替え
- 価格分布のバグ修正
# スクリーンショット
