### PR TITLE
chore: #384 robots.txtにsitemapを指定

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,4 @@
-# See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+User-agent: *
+Disallow:
+
+Sitemap: https://vook.tokyo/sitemap.xml.gz


### PR DESCRIPTION
# issue
- #384 
# やったこと
robots.txtにsitemapを指定

sitemap.xml.gzはすでにSearch Consoleに登録しているが、robots.txtにもサイトマップの場所を指定することで、Google以外の検索エンジンもサイトマップの場所を知ることができる
# スクリーンショット
