### PR TITLE
close #391

### DIFF
--- a/app/views/knowledges/show.html.erb
+++ b/app/views/knowledges/show.html.erb
@@ -49,7 +49,7 @@
       </div>
     </div>
     <%= instagram_embed(@knowledge.instagram_url) if @knowledge.instagram_url.present? %>
-    <% if @knowledge.mermaid_chart %>
+    <% if @knowledge.mermaid_chart.present? %>
       <div class='knowledge-identification'>
         <h3 class='knowledge-sub-title'>
           <%= "#{@knowledge.name}の判別" %>

--- a/spec/system/knowledges_spec.rb
+++ b/spec/system/knowledges_spec.rb
@@ -109,6 +109,12 @@ RSpec.describe '/knowledges', type: :system do
       visit knowledge_path(draft_knowledge)
       expect(page).to have_content '管理者としてログインしてください'
     end
+
+    it '判別方法が空の場合に項目が表示されないこと' do
+      knowledge.update(mermaid_chart: '')
+      visit knowledge_path(knowledge)
+      expect(page).to have_no_content '判別'
+    end
   end
 
   describe 'update' do


### PR DESCRIPTION
# issue
- #391 
知識がcreate/updateされた際にmermaid_chartカラムが空文字に変換されるためbugが生じていた
# やったこと
nilや空文字の際には表示されないよう修正
spec追加
# スクリーンショット
