### PR TITLE
close #397

### DIFF
--- a/app/assets/stylesheets/base_color.scss
+++ b/app/assets/stylesheets/base_color.scss
@@ -37,3 +37,9 @@ $info: $dark-gray;
 $success: $denim;
 $danger: $red;
 $light: $light-gray;
+$secondary-invert: findColorInvert($secondary) !default;
+$secondary-light: findLightColor($secondary) !default;
+$secondary-dark: findDarkColor($secondary) !default;
+$custom-colors: (
+  'secondary': ($secondary, $secondary-invert, $secondary-light, $secondary-dark)
+);

--- a/app/assets/stylesheets/knowledge.scss
+++ b/app/assets/stylesheets/knowledge.scss
@@ -190,6 +190,9 @@
           margin-bottom: 24px;
         }
       }
+      .product-link .button {
+        border: $primary solid 1px;
+      }
     }
   }
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -4,6 +4,8 @@ class ProductsController < ApplicationController
     @products = @knowledge.products.includes(platform: { image_attachment: :blob }).by_size(params[:size])
     @sizes = Size.where(id: @products.select(:size_id).distinct)
 
+    redirect_to root_path, alert: 'コンテンツが存在しません' and return if @products.empty? && !admin_login?
+
     respond_to do |format|
       format.html
       format.js { render partial: 'products/list', locals: { products: @products } }

--- a/app/views/knowledges/show.html.erb
+++ b/app/views/knowledges/show.html.erb
@@ -65,8 +65,8 @@
       </h3>
       <div id='price-histogram' class='knowledge-price-histogram'></div>
       <div class='knowledge-price-body'>
-        <div class='knowledge-price-info level'>
-          <% if @knowledge.products&.average(:price) %>
+        <% if @knowledge.products&.average(:price) %>
+          <div class='knowledge-price-info level'>
             <div class='level-item has-text-centered'>
               <div>
                 <p class='heading'>平均価格</p>
@@ -91,13 +91,13 @@
                 </p>
               </div>
             </div>
-          <% else %>
-            <p>現在、価格情報はありません</p>
-          <% end %>
-        </div>
-        <div class='produt-link has-text-right'>
-          <%= link_to '商品一覧ページへ', product_path(@knowledge) %>
-        </div>
+          </div>
+          <div class='product-link has-text-right'>
+            <%= link_to '商品一覧ページへ', product_path(@knowledge), class: 'button is-secondary' %>
+          </div>
+        <% else %>
+          <p>現在、価格情報はありません</p>
+        <% end %>
       </div>
     </div>
     <div class='knowledge-relation'>

--- a/spec/system/knowledges_spec.rb
+++ b/spec/system/knowledges_spec.rb
@@ -91,29 +91,55 @@ RSpec.describe '/knowledges', type: :system do
       expect(page).to have_content 'この知識にはイメージがありません'
     end
 
-    it '管理者以外は編集と削除ボタンが表示されないこと' do
-      sign_in_as(user)
-      visit knowledge_path(knowledge)
-      expect(page).to have_no_content '編集'
-      expect(page).to have_no_content '削除'
-    end
-
-    it '下書きの知識記事が管理者にのみ表示されること' do
-      sign_in_as(admin)
-      visit knowledge_path(draft_knowledge)
-      expect(page).to have_content draft_knowledge.name
-    end
-
-    it '下書きの知識記事が非管理者には表示されないこと' do
-      sign_in_as(user)
-      visit knowledge_path(draft_knowledge)
-      expect(page).to have_content '管理者としてログインしてください'
-    end
-
     it '判別方法が空の場合に項目が表示されないこと' do
       knowledge.update(mermaid_chart: '')
       visit knowledge_path(knowledge)
       expect(page).to have_no_content '判別'
+    end
+
+    it '商品が存在する場合に商品ページへの導線が表示されること' do
+      create(:product, knowledge:)
+      visit knowledge_path(knowledge)
+      expect(page).to have_content '商品一覧ページへ'
+    end
+
+    it '商品がない場合に導線が表示されないこと' do
+      visit knowledge_path(knowledge)
+      expect(page).to have_no_content '商品一覧ページへ'
+    end
+
+    context '管理者の場合' do
+      before do
+        sign_in_as(admin)
+      end
+
+      it '編集と削除ボタンが表示されること' do
+        visit knowledge_path(knowledge)
+        expect(page).to have_content '編集'
+        expect(page).to have_content '削除'
+      end
+
+      it '下書きの知識記事が表示されること' do
+        visit knowledge_path(draft_knowledge)
+        expect(page).to have_content draft_knowledge.name
+      end
+    end
+
+    context '管理者以外の場合' do
+      before do
+        sign_in_as(user)
+      end
+
+      it '編集と削除ボタンが表示されないこと' do
+        visit knowledge_path(knowledge)
+        expect(page).to have_no_content '編集'
+        expect(page).to have_no_content '削除'
+      end
+
+      it '下書きの知識記事が表示されないこと' do
+        visit knowledge_path(draft_knowledge)
+        expect(page).to have_content '管理者としてログインしてください'
+      end
     end
   end
 

--- a/spec/system/products_spec.rb
+++ b/spec/system/products_spec.rb
@@ -2,23 +2,47 @@ require 'rails_helper'
 
 RSpec.describe 'Products', type: :system do
   let!(:product) { create(:product) }
+  let(:user) { create(:user) }
+  let(:admin) { create(:admin) }
 
   describe 'show' do
-    before do
-      create(:product2, knowledge: product.knowledge)
+    context '商品が存在する場合' do
+      before do
+        create(:product2, knowledge: product.knowledge)
+      end
+
+      it '商品ページが存在すること' do
+        visit product_path(knowledge_id: product.knowledge.id)
+        expect(page).to have_content 'ALL'
+        expect(page).to have_content "リーバイス 501 ネイビー LEVI'S 66前期 BIGE 初期 w28 001"
+      end
+
+      it 'サイズボタンを押すとサイズに紐づいた商品が表示されること' do
+        visit product_path(knowledge_id: product.knowledge.id)
+        click_on 'w32'
+        expect(page).to have_content "リーバイス 501 ネイビー LEVI'S 66前期 BIGE 初期 w32 002"
+        expect(page).not_to have_content "リーバイス 501 ネイビー LEVI'S 66前期 BIGE 初期 w28 001"
+      end
     end
 
-    it '商品ページが存在すること' do
-      visit product_path(knowledge_id: product.knowledge.id)
-      expect(page).to have_content 'ALL'
-      expect(page).to have_content "リーバイス 501 ネイビー LEVI'S 66前期 BIGE 初期 w28 001"
-    end
+    context '商品が存在しない場合' do
+      before do
+        product.knowledge.products.delete_all
+      end
 
-    it 'サイズボタンを押すとサイズに紐づいた商品が表示されること' do
-      visit product_path(knowledge_id: product.knowledge.id)
-      click_on 'w32'
-      expect(page).to have_content "リーバイス 501 ネイビー LEVI'S 66前期 BIGE 初期 w32 002"
-      expect(page).not_to have_content "リーバイス 501 ネイビー LEVI'S 66前期 BIGE 初期 w28 001"
+      it 'トップページにリダイレクトされること' do
+        sign_in_as(user)
+        visit product_path(knowledge_id: product.knowledge.id)
+        expect(page).to have_current_path root_path
+        expect(page).to have_content 'コンテンツが存在しません'
+      end
+
+      it '管理者ではページが表示されること' do
+        sign_in_as(admin)
+        visit product_path(knowledge_id: product.knowledge.id)
+        expect(page).to have_current_path product_path(knowledge_id: product.knowledge.id), ignore_query: true
+        expect(page).to have_content '現在、商品情報はありません'
+      end
     end
   end
 end


### PR DESCRIPTION
# issue
- #397 
# やったこと
商品がない場合に商品ページリンクを非表示
リンクをボタンに改良
spec追加
# スクリーンショット
<img width="1063" alt="image" src="https://github.com/atsushimemet/vook_web_v3/assets/69446373/118546c4-7350-4b57-8e2a-91cb2bd25829">
