### PR TITLE
fix: #467 nginxを再起動する

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -12,5 +12,7 @@ RAILS_ENV=production bundle exec rails db:migrate
 # アセットのプリコンパイル
 RAILS_ENV=production bundle exec rails assets:precompile
 
+# Nginxを再起動
+sudo systemctl restart nginx
 # Pumaを再起動
 sudo systemctl restart puma


### PR DESCRIPTION
# issue
- deploy.shでnginxを再起動できない
# やったこと
- deploy.shでnginxを再起動できるようにした
# 背景
- webを再起動させるためにdeploy.shを実行したが、再起動できなかった。
- 再起動用のスクリプトではないが、コマンド一つで再起動できるので、この内部で修正した